### PR TITLE
Use input to override diff check in build_wasm workflow

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -2,6 +2,13 @@ name: build wasm package
 
 on:
   workflow_call:
+    inputs:
+      # Allows other workflows to explicitly control whether this workflow runs
+      build:
+        required: true
+        description: 'Whether to build the package'
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -17,8 +24,8 @@ jobs:
 
   build:
     needs: detect-changes
-    # Run if changes are detected OR if the workflow was called from another workflow
-    if: needs.detect-changes.outputs.changed == 'true' || github.event_name == 'workflow_call'
+    # Run if changes are detected OR if explicitly requested by another workflow
+    if: needs.detect-changes.outputs.changed == 'true' || inputs.build
     name: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish_wasm.yml
+++ b/.github/workflows/publish_wasm.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   build:
-    # Only run this job if the release tag starts with "hyperwasm@v"
-    if: startsWith(github.ref, 'refs/tags/hyperwasm@v')
     uses: ./.github/workflows/build_wasm.yml
+    with:
+      # Only run this job if the release tag starts with "hyperwasm@v"
+      build: ${{ startsWith(github.ref, 'refs/tags/hyperwasm@v') }}
 
   publish:
     needs: build


### PR DESCRIPTION
Turns out the `github.event_name` is inherited from the workflow that started the chain, so you can't explicitly check if one was called was called via the `workflow_call` trigger. But, we can use an input to explicitly control it.