### PR TITLE
Add `calcImpliedRate` method to hyperwasm

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: delvtech/hyperdrive
-          ref: "v1.0.1"
+          ref: "v1.0.3"
           path: "./hyperdrive"
 
       - name: build hyperdrive-wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-wasm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "console_error_panic_hook",
  "const-hex",

--- a/crates/hyperdrive-wasm/Cargo.toml
+++ b/crates/hyperdrive-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdrive-wasm"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 
 [lib]

--- a/crates/hyperdrive-wasm/example/package.json
+++ b/crates/hyperdrive-wasm/example/package.json
@@ -17,6 +17,6 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.12.0.tgz"
+    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.13.0.tgz"
   }
 }

--- a/crates/hyperdrive-wasm/src/short/open.rs
+++ b/crates/hyperdrive-wasm/src/short/open.rs
@@ -31,12 +31,11 @@ pub fn calcOpenShort(
         info: poolInfo.into(),
         config: poolConfig.into(),
     };
-    let short_amount = FixedPoint::from(U256::from_dec_str(bondAmount).unwrap());
+    let bond_amount = FixedPoint::from(U256::from_dec_str(bondAmount).unwrap());
     let open_vault_share_price = FixedPoint::from(U256::from_dec_str(openVaultSharePrice).unwrap());
-    let spot_price = state.calculate_spot_price();
 
     let result_fp = state
-        .calculate_open_short(short_amount, spot_price, open_vault_share_price)
+        .calculate_open_short(bond_amount, open_vault_share_price)
         .unwrap();
 
     U256::from(result_fp).to_string()

--- a/crates/hyperdrive-wasm/src/short/open.rs
+++ b/crates/hyperdrive-wasm/src/short/open.rs
@@ -1,4 +1,4 @@
-use ethers::types::U256;
+use ethers::types::{I256, U256};
 use fixed_point::FixedPoint;
 use hyperdrive_math::State;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -67,4 +67,40 @@ pub fn spotPriceAfterShort(
         .unwrap();
 
     U256::from(result_fp).to_string()
+}
+
+/// Calculate the implied rate of opening a short at a given size. This rate
+/// is calculated as an APY.
+/// @param poolInfo - The current state of the pool
+///
+/// @param poolConfig - The pool's configuration
+///
+/// @param bondAmount - The amount of bonds to short
+///
+/// @param openVaultSharePrice - The vault share price at the start of the
+/// checkpoint
+///
+/// @param variableApy - The variable apy
+#[wasm_bindgen(skip_jsdoc)]
+pub fn calcImpliedRate(
+    poolInfo: &JsPoolInfo,
+    poolConfig: &JsPoolConfig,
+    bondAmount: &str,
+    openVaultSharePrice: &str,
+    variableApy: &str,
+) -> String {
+    set_panic_hook();
+    let state = State {
+        info: poolInfo.into(),
+        config: poolConfig.into(),
+    };
+    let bond_amount = FixedPoint::from(U256::from_dec_str(bondAmount).unwrap());
+    let open_vault_share_price = FixedPoint::from(U256::from_dec_str(openVaultSharePrice).unwrap());
+    let variable_apy = FixedPoint::from(U256::from_dec_str(variableApy).unwrap());
+
+    let result_fp = state
+        .calculate_implied_rate(bond_amount, open_vault_share_price, variable_apy)
+        .unwrap();
+
+    I256::from(result_fp).to_string()
 }


### PR DESCRIPTION
Related to https://github.com/delvtech/hyperdrive/pull/998 and https://github.com/delvtech/hyperdrive/issues/996

This wraps the `calculate_implied_rate` method from Rust that we'll use in the frontend to show the effective apy for shorts